### PR TITLE
Fix issue with ydk not downloading models which are not in capabilities

### DIFF
--- a/sdk/cpp/core/src/ietf_parser.cpp
+++ b/sdk/cpp/core/src/ietf_parser.cpp
@@ -112,6 +112,18 @@ IetfCapabilitiesParser::~IetfCapabilitiesParser()
 
 }
 
+
+unordered_map<string, path::Capability>
+IetfCapabilitiesParser::get_lookup_table(vector<path::Capability>& capabilities) const
+{
+    unordered_map<string, path::Capability> name_namespace_lookup;
+    for (auto &c: capabilities)
+    {
+        name_namespace_lookup.insert(make_pair(c.module, c));
+    }
+    return name_namespace_lookup;
+}
+
 unordered_map<string, path::Capability>
 IetfCapabilitiesParser::get_lookup_table(vector<string>& capabilities) const
 {
@@ -119,10 +131,10 @@ IetfCapabilitiesParser::get_lookup_table(vector<string>& capabilities) const
 
     auto segs = segmentalize_capabilities(capabilities);
 
-    for (auto &c: segs)
+    for (auto &s: segs)
     {
-        name_namespace_lookup.insert(make_pair(c.second.module, c.second));
-        name_namespace_lookup.insert(make_pair(c.first, c.second));
+        name_namespace_lookup.insert(make_pair(s.second.module, s.second));
+        name_namespace_lookup.insert(make_pair(s.first, s.second));
     }
 
     return name_namespace_lookup;

--- a/sdk/cpp/core/src/ietf_parser.hpp
+++ b/sdk/cpp/core/src/ietf_parser.hpp
@@ -50,6 +50,7 @@ class IetfCapabilitiesParser : public CapabilitiesParser
 
         std::vector<path::Capability> parse(std::vector<std::string> & capabilities) const;
         std::unordered_map<std::string, path::Capability> get_lookup_table(std::vector<std::string>& capabilities) const;
+        std::unordered_map<std::string, path::Capability> get_lookup_table(std::vector<path::Capability>& capabilities) const;
         std::vector<std::pair<std::string, path::Capability>> segmentalize_capabilities(std::vector<std::string>& capabilities) const;
 };
 }

--- a/sdk/python/core/ydk/providers/codec_provider.py
+++ b/sdk/python/core/ydk/providers/codec_provider.py
@@ -109,7 +109,7 @@ class CodecServiceProvider(object):
         # TODO: turn on and off libyang logging
         capabilities = []
         lookup_tables = self._get_bundle_capability_lookup_table(bundle_name)
-        self._root_schema_table[name] = repo.create_root_schema(lookup_table, capabilities)
+        self._root_schema_table[name] = repo.create_root_schema(lookup_tables, capabilities)
 
     def _get_bundle_yang_ns(self, bundle_name):
         """Search installed local ydk-models python packages, and return _yang_ns


### PR DESCRIPTION
* loose module name/namespace predicate function constraints
* map module namespace to module name, always load module using module name
* add namespace to capability mapping to core mock data
  * use `create_root_schema` with only one parameter uses [empty lookup table](https://github.com/psykokwak4/ydk-gen/blob/ae2a5409a5b5735c1539a9ea2a5102f8789665c9/sdk/cpp/core/src/path/repository.cpp#L539)(added for [provider](https://github.com/psykokwak4/ydk-gen/blob/ae2a5409a5b5735c1539a9ea2a5102f8789665c9/sdk/cpp/core/src/opendaylight_provider.cpp#L84) not support module downloading)